### PR TITLE
fix(tasks): chained state watching on user viewable projects

### DIFF
--- a/lib/services/data/common/widgets/form/base_project_selection_field.dart
+++ b/lib/services/data/common/widgets/form/base_project_selection_field.dart
@@ -1,24 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:seren_ai_flutter/services/data/common/widgets/form/selection_field.dart';
+import 'package:seren_ai_flutter/services/data/orgs/cur_org/is_cur_user_org_admin_listener_provider.dart';
+import 'package:seren_ai_flutter/services/data/projects/cur_user_projects_listener_provider.dart';
+import 'package:seren_ai_flutter/services/data/projects/cur_user_viewable_projects_listener_provider.dart';
 import 'package:seren_ai_flutter/services/data/projects/models/project_model.dart';
 
 class BaseProjectSelectionField extends ConsumerWidget {
   final bool enabled;
   final ProviderListenable<ProjectModel?> projectProvider;
-  final ProviderListenable<List<ProjectModel>?> selectableProjectsProvider;
   final Function(WidgetRef, ProjectModel?) updateProject;
 
   const BaseProjectSelectionField({
     super.key,
     required this.enabled,
     required this.projectProvider,
-    required this.selectableProjectsProvider,
     required this.updateProject,
   });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isCurUserOrgAdmin = ref.watch(isCurUserOrgAdminListenerProvider);
+    final selectableProjectsProvider = isCurUserOrgAdmin
+        ? curUserViewableProjectsListenerProvider
+        : curUserProjectsListenerProvider;
     final curTaskProject = ref.watch(projectProvider);
     final selectableProjects = ref.watch(selectableProjectsProvider);
 

--- a/lib/services/data/notes/widgets/form/note_folder_selection_fields.dart
+++ b/lib/services/data/notes/widgets/form/note_folder_selection_fields.dart
@@ -34,7 +34,6 @@ class NoteFolderParentProjectField extends BaseProjectSelectionField {
     required super.enabled,
   }) : super(
           projectProvider: curNoteFolderParentProjectProvider,
-          selectableProjectsProvider: curUserViewableProjectsListenerProvider,
           updateProject: (ref, project) => 
               ref.read(curNoteFolderProvider.notifier).updateParentProject(project),
         );

--- a/lib/services/data/projects/cur_user_viewable_projects_listener_provider.dart
+++ b/lib/services/data/projects/cur_user_viewable_projects_listener_provider.dart
@@ -1,47 +1,32 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:seren_ai_flutter/services/data/db_setup/db_provider.dart';
 import 'package:seren_ai_flutter/services/data/orgs/cur_org/cur_org_id_provider.dart';
-import 'package:seren_ai_flutter/services/data/orgs/cur_org/is_cur_user_org_admin_listener_provider.dart';
-import 'package:seren_ai_flutter/services/data/projects/cur_user_projects_listener_provider.dart';
 import 'package:seren_ai_flutter/services/data/projects/models/project_model.dart';
 
-final curUserViewableProjectsListenerProvider =
-    NotifierProvider<CurUserViewableProjectsListenerProvider, List<ProjectModel>?>(
-        CurUserViewableProjectsListenerProvider.new);
+final curUserViewableProjectsListenerProvider = NotifierProvider<
+    CurUserViewableProjectsListenerProvider,
+    List<ProjectModel>?>(CurUserViewableProjectsListenerProvider.new);
 
-class CurUserViewableProjectsListenerProvider extends Notifier<List<ProjectModel>?> {
+class CurUserViewableProjectsListenerProvider
+    extends Notifier<List<ProjectModel>?> {
   @override
   List<ProjectModel>? build() {
-    final watchedIsCurUserOrgAdmin =
-        ref.watch(isCurUserOrgAdminListenerProvider);
+    final watchedCurOrgId = ref.watch(curOrgIdProvider);
+    final query =
+        "SELECT * FROM projects WHERE parent_org_id = '$watchedCurOrgId'";
 
-    if (watchedIsCurUserOrgAdmin) {
-      final watchedCurOrgId = ref.watch(curOrgIdProvider);
-      final query =
-          "SELECT * FROM projects WHERE parent_org_id = '$watchedCurOrgId'";
+    final db = ref.read(dbProvider);
 
-      final db = ref.read(dbProvider);
+    final subscription = db.watch(query).listen((results) {
+      List<ProjectModel> items =
+          results.map((e) => ProjectModel.fromJson(e)).toList();
+      state = items;
+    });
 
-      final subscription = db.watch(query).listen((results) {
-        List<ProjectModel> items =
-            results.map((e) => ProjectModel.fromJson(e)).toList();
-        state = items;
-      });
-
-      // Cancel the subscription when the notifier is disposed
-      ref.onDispose(() {
-        subscription.cancel();
-      });
-    } else {
-      // get all projects that the current user has a role in
-      final userProjects = ref.watch(curUserProjectsListenerProvider);
-      if (userProjects != null) {
-        state = userProjects;
-      } else {
-        state = [];
-      }
-    }
-
+    // Cancel the subscription when the notifier is disposed
+    ref.onDispose(() {
+      subscription.cancel();
+    });
     // Return the initial state
     return null;
   }

--- a/lib/services/data/tasks/widgets/form/task_selection_fields.dart
+++ b/lib/services/data/tasks/widgets/form/task_selection_fields.dart
@@ -28,7 +28,6 @@ class TaskProjectSelectionField extends BaseProjectSelectionField {
     required super.enabled,
   }) : super(
           projectProvider: curTaskProjectProvider,
-          selectableProjectsProvider: curUserViewableProjectsListenerProvider,
           updateProject: (ref, project) =>
               ref.read(curTaskProvider.notifier).updateParentProject(project),
         );


### PR DESCRIPTION
CurUserViewableProjectsListenerProvider state wasn't being correctly watched by BaseProjectSelectionField when isCurUserOrgAdmin == false, so the provider selection logic was moved into the widget