### PR TITLE
feat: add default project and team for users

### DIFF
--- a/lib/services/data/common/widgets/form/base_task_name_field.dart
+++ b/lib/services/data/common/widgets/form/base_task_name_field.dart
@@ -47,6 +47,7 @@ class BaseNameField extends HookConsumerWidget {
     return AnimatedBuilder(
       animation: colorAnimation.colorTween,
       builder: (context, child) {
+        nameController.text = curName;
         return TextField(
           focusNode: focusNode,
           controller: nameController,

--- a/lib/services/data/db_setup/schema.dart
+++ b/lib/services/data/db_setup/schema.dart
@@ -18,6 +18,8 @@ const permissionSchemas = [
     Column.text('id'),
     Column.text('parent_auth_user_id'),
     Column.text('email'),
+    Column.text('default_project_id'),
+    Column.text('default_team_id'),
   ]),
   Table(orgsTable, [
     Column.text('id'),

--- a/lib/services/data/notes/cur_user_viewable_note_folders_listener_provider.dart
+++ b/lib/services/data/notes/cur_user_viewable_note_folders_listener_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:seren_ai_flutter/services/auth/cur_auth_user_provider.dart';
 import 'package:seren_ai_flutter/services/data/db_setup/db_provider.dart';
 import 'package:seren_ai_flutter/services/data/notes/models/note_folder_model.dart';
 import 'package:seren_ai_flutter/services/data/projects/cur_user_viewable_projects_listener_provider.dart';
@@ -13,12 +12,6 @@ final curUserViewableNoteFoldersListenerProvider =
 class CurUserViewableNoteFoldersListenerNotifier extends Notifier<List<NoteFolderModel>?> {
   @override
   List<NoteFolderModel>? build() {
-    final watchedCurAuthUser = ref.watch(curAuthUserProvider);
-
-    if (watchedCurAuthUser == null) {
-      return null;
-    }
-
     final db = ref.read(dbProvider);
 
     final curTeams = ref.watch(curUserViewableTeamsListenerProvider);

--- a/lib/services/data/notes/ui_state/cur_note_folder_provider.dart
+++ b/lib/services/data/notes/ui_state/cur_note_folder_provider.dart
@@ -1,84 +1,173 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:seren_ai_flutter/services/auth/auth_states.dart';
+import 'package:seren_ai_flutter/services/auth/cur_auth_user_provider.dart';
 import 'package:seren_ai_flutter/services/data/notes/models/joined_note_folder_model.dart';
 import 'package:seren_ai_flutter/services/data/notes/models/note_folder_model.dart';
+import 'package:seren_ai_flutter/services/data/notes/note_folders_read_provider.dart';
 import 'package:seren_ai_flutter/services/data/projects/models/project_model.dart';
+import 'package:seren_ai_flutter/services/data/projects/projects_read_provider.dart';
 import 'package:seren_ai_flutter/services/data/teams/models/team_model.dart';
+import 'package:seren_ai_flutter/services/data/teams/teams_read_provider.dart';
+import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_folder_states.dart';
 
 final curNoteFolderProvider =
-    NotifierProvider<CurNoteFolderNotifier, JoinedNoteFolderModel>(CurNoteFolderNotifier.new);
+    NotifierProvider<CurNoteFolderNotifier, CurNoteFolderState>(
+        CurNoteFolderNotifier.new);
 
-class CurNoteFolderNotifier extends Notifier<JoinedNoteFolderModel> {
+class CurNoteFolderNotifier extends Notifier<CurNoteFolderState> {
   @override
-  JoinedNoteFolderModel build() {
-    return JoinedNoteFolderModel.empty();
+  CurNoteFolderState build() {
+    return InitialCurNoteFolderState();
   }
 
   void setNewNoteFolder(JoinedNoteFolderModel joinedNoteFolder) {
-    state = joinedNoteFolder;
+    state = LoadedCurNoteFolderState(joinedNoteFolder);
   }
 
-  void setToNewNoteFolder() {
-    state = JoinedNoteFolderModel.empty();
+  Future<void> setToNewNoteFolder() async {
+    state = LoadingCurNoteFolderState();
+    try {
+      final curUser = (ref.read(curAuthUserProvider) as LoggedInAuthState).user;
+
+      final defaultTeam = await ref.read(teamsReadProvider).getItem(eqFilters: [
+        {'key': 'id', 'value': curUser.defaultTeamId}
+      ]);
+      final defaultProject =
+          await ref.read(projectsReadProvider).getItem(eqFilters: [
+        {'key': 'id', 'value': curUser.defaultProjectId}
+      ]);
+      final newNoteFolder = NoteFolderModel.defaultNoteFolder().copyWith(
+        parentTeamId: defaultTeam?.id,
+        parentProjectId: defaultProject?.id,
+      );
+      state = LoadedCurNoteFolderState(JoinedNoteFolderModel(
+        noteFolder: newNoteFolder,
+        team: defaultTeam,
+        project: defaultProject,
+      ));
+    } catch (error) {
+      state = ErrorCurNoteFolderState(error: error.toString());
+    }
   }
 
   bool isValidNoteFolder() {
-    return state.noteFolder.name.isNotEmpty && state.noteFolder.parentProjectId.isNotEmpty;
+    if (state is LoadedCurNoteFolderState) {
+      final loadedState = state as LoadedCurNoteFolderState;
+      return state is LoadedCurNoteFolderState &&
+          loadedState.noteFolder.noteFolder.name.isNotEmpty &&
+          loadedState.noteFolder.noteFolder.parentProjectId.isNotEmpty;
+    }
+    return false;
   }
 
   void updateNoteFolder(NoteFolderModel noteFolder) {
-    state = state.copyWith(noteFolder: noteFolder);
+    if (state is LoadedCurNoteFolderState) {
+      final loadedState = state as LoadedCurNoteFolderState;
+      state = LoadedCurNoteFolderState(
+          loadedState.noteFolder.copyWith(noteFolder: noteFolder));
+    }
   }
 
   void updateNoteFolderName(String name) {
-    state = state.copyWith(noteFolder: state.noteFolder.copyWith(name: name));
+    if (state is LoadedCurNoteFolderState) {
+      final loadedState = state as LoadedCurNoteFolderState;
+      state = LoadedCurNoteFolderState(loadedState.noteFolder.copyWith(
+          noteFolder: loadedState.noteFolder.noteFolder.copyWith(name: name)));
+    }
   }
 
   void updateDescription(String? description) {
-    state = state.copyWith(noteFolder: state.noteFolder.copyWith(description: description));
+    if (state is LoadedCurNoteFolderState) {
+      final loadedState = state as LoadedCurNoteFolderState;
+      state = LoadedCurNoteFolderState(loadedState.noteFolder.copyWith(
+          noteFolder: loadedState.noteFolder.noteFolder
+              .copyWith(description: description)));
+    }
   }
 
   void updateAllFields(JoinedNoteFolderModel joinedNoteFolder) {
-    state = joinedNoteFolder;
+    state = LoadedCurNoteFolderState(joinedNoteFolder);
   }
 
   void updateParentProject(ProjectModel? project) {
-    state = state.copyWith(
-      noteFolder: state.noteFolder.copyWith(parentProjectId: project?.id),
-      project: project
-    );
+    if (state is LoadedCurNoteFolderState) {
+      final loadedState = state as LoadedCurNoteFolderState;
+      state = LoadedCurNoteFolderState(loadedState.noteFolder.copyWith(
+          noteFolder: loadedState.noteFolder.noteFolder
+              .copyWith(parentProjectId: project?.id),
+          project: project));
+    }
   }
 
   void updateParentTeam(TeamModel? team) {
-    state = state.copyWith(
-      noteFolder: state.noteFolder.copyWith(parentTeamId: team?.id),
-      team: team
-    );
+    if (state is LoadedCurNoteFolderState) {
+      final loadedState = state as LoadedCurNoteFolderState;
+      state = LoadedCurNoteFolderState(loadedState.noteFolder.copyWith(
+          noteFolder: loadedState.noteFolder.noteFolder
+              .copyWith(parentTeamId: team?.id),
+          team: team));
+    }
+  }
+
+  Future<void> saveNoteFolder() async {
+    if (state is LoadedCurNoteFolderState) {
+      final loadedState = state as LoadedCurNoteFolderState;
+      await ref
+          .read(noteFoldersReadProvider)
+          .upsertItem(loadedState.noteFolder.noteFolder);
+    }
   }
 }
 
 // Providers for individual fields
 
 final curNoteFolderNameProvider = Provider<String>((ref) {
-  return ref.watch(curNoteFolderProvider.select((state) => state.noteFolder.name));
+  final curNoteFolderState = ref.watch(curNoteFolderProvider);
+  return switch (curNoteFolderState) {
+    LoadedCurNoteFolderState() => curNoteFolderState.noteFolder.noteFolder.name,
+    _ => '',
+  };
 });
 
 final curNoteFolderDescriptionProvider = Provider<String?>((ref) {
-  return ref.watch(curNoteFolderProvider.select((state) => state.noteFolder.description));
+  final curNoteFolderState = ref.watch(curNoteFolderProvider);
+  return switch (curNoteFolderState) {
+    LoadedCurNoteFolderState() =>
+      curNoteFolderState.noteFolder.noteFolder.description,
+    _ => null,
+  };
 });
 
 final curNoteFolderParentTeamIdProvider = Provider<String?>((ref) {
-  return ref.watch(curNoteFolderProvider.select((state) => state.noteFolder.parentTeamId));
+  final curNoteFolderState = ref.watch(curNoteFolderProvider);
+  return switch (curNoteFolderState) {
+    LoadedCurNoteFolderState() =>
+      curNoteFolderState.noteFolder.noteFolder.parentTeamId,
+    _ => null,
+  };
 });
 
-final curNoteFolderParentProjectIdProvider = Provider<String>((ref) {
-  return ref.watch(curNoteFolderProvider.select((state) => state.noteFolder.parentProjectId));
+final curNoteFolderParentProjectIdProvider = Provider<String?>((ref) {
+  final curNoteFolderState = ref.watch(curNoteFolderProvider);
+  return switch (curNoteFolderState) {
+    LoadedCurNoteFolderState() =>
+      curNoteFolderState.noteFolder.noteFolder.parentProjectId,
+    _ => null,
+  };
 });
 
 final curNoteFolderParentProjectProvider = Provider<ProjectModel?>((ref) {
-  return ref.watch(curNoteFolderProvider.select((state) => state.project));
+  final curNoteFolderState = ref.watch(curNoteFolderProvider);
+  return switch (curNoteFolderState) {
+    LoadedCurNoteFolderState() => curNoteFolderState.noteFolder.project,
+    _ => null,
+  };
 });
 
 final curNoteFolderParentTeamProvider = Provider<TeamModel?>((ref) {
-  return ref.watch(curNoteFolderProvider.select((state) => state.team));
+  final curNoteFolderState = ref.watch(curNoteFolderProvider);
+  return switch (curNoteFolderState) {
+    LoadedCurNoteFolderState() => curNoteFolderState.noteFolder.team,
+    _ => null,
+  };
 });

--- a/lib/services/data/notes/ui_state/cur_note_folder_states.dart
+++ b/lib/services/data/notes/ui_state/cur_note_folder_states.dart
@@ -1,0 +1,19 @@
+import 'package:seren_ai_flutter/services/data/notes/models/joined_note_folder_model.dart';
+
+abstract class CurNoteFolderState {}
+
+class InitialCurNoteFolderState extends CurNoteFolderState {}
+
+class LoadingCurNoteFolderState extends CurNoteFolderState {}
+
+class LoadedCurNoteFolderState extends CurNoteFolderState {
+  final JoinedNoteFolderModel noteFolder;
+
+  LoadedCurNoteFolderState(this.noteFolder);
+}
+
+class ErrorCurNoteFolderState extends CurNoteFolderState {
+  final String error;
+
+  ErrorCurNoteFolderState({required this.error});
+}

--- a/lib/services/data/notes/ui_state/cur_note_provider.dart
+++ b/lib/services/data/notes/ui_state/cur_note_provider.dart
@@ -1,119 +1,183 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:seren_ai_flutter/services/data/notes/models/note_model.dart';
+import 'package:seren_ai_flutter/services/data/notes/notes_read_provider.dart';
+import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_states.dart';
 import 'package:seren_ai_flutter/services/data/users/models/user_model.dart';
 
 final curNoteProvider =
-    NotifierProvider<CurNoteNotifier, NoteModel>(CurNoteNotifier.new);
+    NotifierProvider<CurNoteNotifier, CurNoteState>(CurNoteNotifier.new);
 
-class CurNoteNotifier extends Notifier<NoteModel> {
+class CurNoteNotifier extends Notifier<CurNoteState> {
   @override
-  NoteModel build() {
-    return NoteModel.defaultNote();
+  CurNoteState build() {
+    return InitialCurNoteState();
   }
 
   void setNewNote(NoteModel note) {
-    state = note;
+    state = LoadedCurNoteState(note);
   }
 
-  void setToNewNote(UserModel authorUser, String parentNoteFolderId) {
-    state = NoteModel.defaultNote().copyWith(authorUserId: authorUser.id, parentNoteFolderId: parentNoteFolderId);
+  Future<void> setToNewNote(UserModel authorUser, String parentNoteFolderId) async {
+    state = LoadingCurNoteState();
+    try {
+      final newNote = NoteModel.defaultNote().copyWith(
+        authorUserId: authorUser.id,
+        parentNoteFolderId: parentNoteFolderId,
+      );
+      state = LoadedCurNoteState(newNote);
+    } catch (error) {
+      state = ErrorCurNoteState(error: error.toString());
+    }
   }
 
   bool isValidNote() {
-    return state.name.isNotEmpty;
+    return state is LoadedCurNoteState && (state as LoadedCurNoteState).note.name.isNotEmpty;
   }
 
   void updateNote(NoteModel note) {
-    state = note;
+    if (state is LoadedCurNoteState) {
+      state = LoadedCurNoteState(note);
+    }
   }
 
   // We must showDatePicker and update in same method 
   // As the original ref is invalidated after showDatePicker returns 
   Future<void> pickAndUpdateDate(BuildContext context) async {
+    if (state is LoadedCurNoteState) {
+      final loadedState = state as LoadedCurNoteState;
+      final DateTime now = DateTime.now();
+      final DateTime initialDate = loadedState.note.date?.toLocal() ?? now;
 
-    final DateTime now = DateTime.now();
-    final DateTime initialDate = state.date?.toLocal() ?? now;
+      final DateTime? pickedDate = await showDatePicker(
+        context: context,
+        initialDate: initialDate,
+        firstDate: DateTime(2000),
+        lastDate: DateTime(2100),
+      );
 
-    final DateTime? pickedDate = await showDatePicker(
-      context: context,
-      initialDate: initialDate,
-      firstDate: DateTime(2000),
-      lastDate: DateTime(2100),
-    );
+      if (pickedDate != null) {
+        final TimeOfDay? pickedTime = await showTimePicker(
+          context: context,
+          initialTime: TimeOfDay.fromDateTime(initialDate),
+        );
 
-    if (pickedDate != null) {
-          final TimeOfDay? pickedTime = await showTimePicker(
-            context: context,
-            initialTime: TimeOfDay.fromDateTime(initialDate),
-          );
+        if (pickedTime != null) {
+          final DateTime pickedDateTime = DateTime(
+            pickedDate.year,
+            pickedDate.month,
+            pickedDate.day,
+            pickedTime.hour,
+            pickedTime.minute,
+          ).toUtc();
 
-          if (pickedTime != null) {
-            final DateTime pickedDateTime = DateTime(
-              pickedDate.year,
-              pickedDate.month,
-              pickedDate.day,
-              pickedTime.hour,
-              pickedTime.minute,
-            ).toUtc();
-
-            updateDate(pickedDateTime);
+          updateDate(pickedDateTime);
+        }
       }
     }
   }
 
   void updateNoteName(String name) {
-    state = state.copyWith(name: name);
+    if (state is LoadedCurNoteState) {
+      final loadedState = state as LoadedCurNoteState;
+      state = LoadedCurNoteState(loadedState.note.copyWith(name: name));
+    }
   }
 
   void updateDate(DateTime? date) {
-    state = state.copyWith(date: date);
+    if (state is LoadedCurNoteState) {
+      final loadedState = state as LoadedCurNoteState;
+      state = LoadedCurNoteState(loadedState.note.copyWith(date: date));
+    }
   }
 
   void updateAddress(String? address) {
-    state = state.copyWith(address: address);
+    if (state is LoadedCurNoteState) {
+      final loadedState = state as LoadedCurNoteState;
+      state = LoadedCurNoteState(loadedState.note.copyWith(address: address));
+    }
   }
 
   void updateDescription(String? description) {
-    state = state.copyWith(description: description);
+    if (state is LoadedCurNoteState) {
+      final loadedState = state as LoadedCurNoteState;
+      state = LoadedCurNoteState(loadedState.note.copyWith(description: description));
+    }
   }
 
   void updateActionRequired(String? actionRequired) {
-    state = state.copyWith(actionRequired: actionRequired);
+    if (state is LoadedCurNoteState) {
+      final loadedState = state as LoadedCurNoteState;
+      state = LoadedCurNoteState(loadedState.note.copyWith(actionRequired: actionRequired));
+    }
   }
 
   void updateStatus(String? status) {
-    state = state.copyWith(status: status);
+    if (state is LoadedCurNoteState) {
+      final loadedState = state as LoadedCurNoteState;
+      state = LoadedCurNoteState(loadedState.note.copyWith(status: status));
+    }
   }
 
   void updateAllFields(NoteModel note) {
-    state = note;
+    state = LoadedCurNoteState(note);
+  }
+
+  
+  Future<void> saveNote() async {
+    if (state is LoadedCurNoteState) {
+      final loadedState = state as LoadedCurNoteState;
+      await ref.read(notesReadProvider).upsertItem(loadedState.note);
+    }
   }
 }
 
 // Providers for individual fields
 
-final curNoteAuthorProvider = Provider<String>((ref) {
-  return ref.watch(curNoteProvider.select((state) => 
-    state.authorUserId));
+final curNoteAuthorProvider = Provider<String?>((ref) {
+  final curNoteState = ref.watch(curNoteProvider);
+  return switch (curNoteState) {
+    LoadedCurNoteState() => curNoteState.note.authorUserId,
+    _ => null,
+  };
 });
 
 final curNoteDateProvider = Provider<DateTime?>((ref) {
-  return ref.watch(curNoteProvider.select((state) => state.date));
+  final curNoteState = ref.watch(curNoteProvider);
+  return switch (curNoteState) {
+    LoadedCurNoteState() => curNoteState.note.date,
+    _ => null,
+  };
 });
 
 final curNoteAddressProvider = Provider<String?>((ref) {
-  return ref.watch(curNoteProvider.select((state) => state.address));
+  final curNoteState = ref.watch(curNoteProvider);
+  return switch (curNoteState) {
+    LoadedCurNoteState() => curNoteState.note.address,
+    _ => null,
+  };
 });
 
 final curNoteDescriptionProvider = Provider<String?>((ref) {
-  return ref.watch(curNoteProvider.select((state) => state.description));
+  final curNoteState = ref.watch(curNoteProvider);
+  return switch (curNoteState) {
+    LoadedCurNoteState() => curNoteState.note.description,
+    _ => null,
+  };
 });
 
 final curNoteActionRequiredProvider = Provider<String?>((ref) {
-  return ref.watch(curNoteProvider.select((state) => state.actionRequired));
+  final curNoteState = ref.watch(curNoteProvider);
+  return switch (curNoteState) {
+    LoadedCurNoteState() => curNoteState.note.actionRequired,
+    _ => null,
+  };
 });
 
 final curNoteStatusProvider = Provider<String?>((ref) {
-  return ref.watch(curNoteProvider.select((state) => state.status));
+  final curNoteState = ref.watch(curNoteProvider);
+  return switch (curNoteState) {
+    LoadedCurNoteState() => curNoteState.note.status,
+    _ => null,
+  };
 });

--- a/lib/services/data/notes/ui_state/cur_note_states.dart
+++ b/lib/services/data/notes/ui_state/cur_note_states.dart
@@ -1,0 +1,19 @@
+import 'package:seren_ai_flutter/services/data/notes/models/note_model.dart';
+
+sealed class CurNoteState {}
+
+class InitialCurNoteState extends CurNoteState {}
+
+class LoadingCurNoteState extends CurNoteState {}
+
+class LoadedCurNoteState extends CurNoteState {
+  final NoteModel note;
+
+  LoadedCurNoteState(this.note);
+}
+
+class ErrorCurNoteState extends CurNoteState {
+  final String error;
+
+  ErrorCurNoteState({required this.error});
+}

--- a/lib/services/data/notes/widgets/form/note_folder_selection_fields.dart
+++ b/lib/services/data/notes/widgets/form/note_folder_selection_fields.dart
@@ -3,6 +3,7 @@ import 'package:seren_ai_flutter/services/data/common/widgets/form/base_task_nam
 import 'package:seren_ai_flutter/services/data/common/widgets/form/base_team_selection_field.dart';
 import 'package:seren_ai_flutter/services/data/common/widgets/form/base_text_block_edit_selection_field.dart';
 import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_folder_provider.dart';
+import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_folder_states.dart';
 import 'package:seren_ai_flutter/services/data/projects/cur_user_viewable_projects_listener_provider.dart';
 import 'package:seren_ai_flutter/services/data/teams/cur_team/cur_user_viewable_teams_listener_provider.dart';
 
@@ -11,7 +12,10 @@ class NoteFolderNameField extends BaseNameField {
     super.key,
     required super.enabled,
   }) : super(
-          nameProvider: curNoteFolderProvider.select((state) => state.noteFolder.name),
+          nameProvider: curNoteFolderProvider.select((state) => switch (state) {
+                LoadedCurNoteFolderState() => state.noteFolder.noteFolder.name,
+                _ => '',
+              }),
           updateName: (ref, name) => 
               ref.read(curNoteFolderProvider.notifier).updateNoteFolderName(name),
         );
@@ -22,7 +26,10 @@ class NoteFolderDescriptionField extends BaseTextBlockEditSelectionField {
     super.key,
     required super.enabled,
   }) : super(
-          descriptionProvider: curNoteFolderProvider.select((state) => state.noteFolder.description),
+          descriptionProvider: curNoteFolderProvider.select((state) => switch (state) {
+                LoadedCurNoteFolderState() => state.noteFolder.noteFolder.description,
+                _ => null,
+              }),
           updateDescription: (ref, description) => 
               ref.read(curNoteFolderProvider.notifier).updateDescription(description),
         );

--- a/lib/services/data/notes/widgets/form/note_selection_fields.dart
+++ b/lib/services/data/notes/widgets/form/note_selection_fields.dart
@@ -2,14 +2,18 @@ import 'package:seren_ai_flutter/services/data/common/widgets/form/base_text_blo
 import 'package:seren_ai_flutter/services/data/common/widgets/form/base_due_date_selection_field.dart';
 import 'package:seren_ai_flutter/services/data/common/widgets/form/base_task_name_field.dart';
 import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_provider.dart';
+import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_states.dart';
 
 class NoteNameField extends BaseNameField {
   NoteNameField({
     super.key,
     required super.enabled,
   }) : super(
-          nameProvider: curNoteProvider.select((state) => state.name),
-          updateName: (ref, name) => 
+          nameProvider: curNoteProvider.select((state) => switch (state) {
+                LoadedCurNoteState() => state.note.name,
+                _ => '',
+              }),
+          updateName: (ref, name) =>
               ref.read(curNoteProvider.notifier).updateNoteName(name),
         );
 }
@@ -19,8 +23,11 @@ class NoteDueDateSelectionField extends BaseDueDateSelectionField {
     super.key,
     required super.enabled,
   }) : super(
-          dueDateProvider: curNoteProvider.select((state) => state.date),
-          pickAndUpdateDueDate: (ref, context) => 
+          dueDateProvider: curNoteProvider.select((state) => switch (state) {
+                LoadedCurNoteState() => state.note.date,
+                _ => null,
+              }),
+          pickAndUpdateDueDate: (ref, context) =>
               ref.read(curNoteProvider.notifier).pickAndUpdateDate(context),
         );
 }
@@ -30,10 +37,11 @@ class NoteDescriptionSelectionField extends BaseTextBlockEditSelectionField {
     super.key,
     required super.enabled,
   }) : super(
-          descriptionProvider: curNoteProvider.select((state) => state.description),
-          updateDescription: (ref, description) => 
-              ref.read(curNoteProvider.notifier).updateNote(
-                ref.read(curNoteProvider).copyWith(description: description)
-              ),
+          descriptionProvider: curNoteProvider.select((state) => switch (state) {
+                LoadedCurNoteState() => state.note.description,
+                _ => null,
+              }),
+          updateDescription: (ref, description) =>
+              ref.read(curNoteProvider.notifier).updateDescription(description),
         );
 }

--- a/lib/services/data/notes/widgets/note_folder_page.dart
+++ b/lib/services/data/notes/widgets/note_folder_page.dart
@@ -2,11 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:seren_ai_flutter/constants.dart';
-import 'package:seren_ai_flutter/services/auth/cur_auth_user_provider.dart';
 import 'package:seren_ai_flutter/services/data/common/widgets/editablePageModeEnum.dart';
-import 'package:seren_ai_flutter/services/data/common/widgets/form/base_text_block_edit_selection_field.dart';
 import 'package:seren_ai_flutter/services/data/notes/models/joined_note_folder_model.dart';
-import 'package:seren_ai_flutter/services/data/notes/note_folders_read_provider.dart';
 import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_folder_provider.dart';
 import 'package:seren_ai_flutter/services/data/notes/widgets/form/note_folder_selection_fields.dart';
 
@@ -34,8 +31,8 @@ class NoteFolderPage extends HookConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             NoteFolderNameField(enabled: isEnabled),
-            SizedBox(height: 8),
-            Divider(),
+            const SizedBox(height: 8),
+            const Divider(),
 
             // ======================
             // ====== SUBITEMS ======
@@ -58,23 +55,11 @@ class NoteFolderPage extends HookConsumerWidget {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () async {
-                    final curAuthUser = ref.watch(curAuthUserProvider);
-
-                    if (curAuthUser == null) {
-                      log.severe('Error: Current user is not authenticated.');
-                      return;
-                    }
-
                     final isValidNoteFolder =
                         ref.read(curNoteFolderProvider.notifier).isValidNoteFolder();
 
-                    // TODO p2: add validator ui - since we don't use formfield (since we use provider to manage task form state) we must manually implement validation
-
                     if (isValidNoteFolder) {
-                      final curNoteFolder = ref.read(curNoteFolderProvider);
-                      // Save note folder logic here
-
-                      await ref.read(noteFoldersReadProvider).upsertItem(curNoteFolder.noteFolder);
+                      ref.read(curNoteFolderProvider.notifier).saveNoteFolder();
 
                       if (context.mounted) {
                         Navigator.pop(context);
@@ -97,7 +82,7 @@ class NoteFolderPage extends HookConsumerWidget {
                     Navigator.pop(context);
                     openNoteFolderPage(context, ref, mode: EditablePageMode.edit);
                   },
-                  child: Text('Edit'))
+                  child: const Text('Edit'))
           ],
         ),
       ),
@@ -111,10 +96,6 @@ Future<void> openNoteFolderPage(BuildContext context, WidgetRef ref,
   Navigator.popUntil(context, (route) => route.settings.name != noteFolderPageRoute);
 
   if (mode == EditablePageMode.create) {
-    final authUser = ref.watch(curAuthUserProvider);
-    if (authUser == null) {
-      throw Exception('Error: Current user is not authenticated.');
-    }
     ref.read(curNoteFolderProvider.notifier).setToNewNoteFolder();
   } 
   // EDIT/READ

--- a/lib/services/data/notes/widgets/note_page.dart
+++ b/lib/services/data/notes/widgets/note_page.dart
@@ -7,7 +7,6 @@ import 'package:seren_ai_flutter/services/auth/cur_auth_user_provider.dart';
 import 'package:seren_ai_flutter/services/data/common/widgets/editablePageModeEnum.dart';
 import 'package:seren_ai_flutter/services/data/common/widgets/form/base_text_block_edit_selection_field.dart';
 import 'package:seren_ai_flutter/services/data/notes/notes_read_provider.dart';
-import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_folder_provider.dart';
 import 'package:seren_ai_flutter/services/data/notes/ui_state/cur_note_provider.dart';
 import 'package:seren_ai_flutter/services/data/notes/widgets/form/note_selection_fields.dart';
 
@@ -15,7 +14,7 @@ final log = Logger('NotePage');
 
 /// For creating / editing a note
 class NotePage extends HookConsumerWidget {
-  final EditablePageMode mode;  
+  final EditablePageMode mode;
 
   const NotePage({
     super.key,
@@ -35,8 +34,8 @@ class NotePage extends HookConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             NoteNameField(enabled: isEnabled),
-            SizedBox(height: 8),
-            Divider(),
+            const SizedBox(height: 8),
+            const Divider(),
 
             // ======================
             // ====== SUBITEMS ======
@@ -52,15 +51,17 @@ class NotePage extends HookConsumerWidget {
                   BaseTextBlockEditSelectionField(
                     enabled: isEnabled,
                     descriptionProvider: curNoteAddressProvider,
-                    updateDescription: (ref, address) =>
-                        ref.read(curNoteProvider.notifier).updateAddress(address),
+                    updateDescription: (ref, address) => ref
+                        .read(curNoteProvider.notifier)
+                        .updateAddress(address),
                   ),
                   const Divider(),
                   BaseTextBlockEditSelectionField(
                     enabled: isEnabled,
                     descriptionProvider: curNoteActionRequiredProvider,
-                    updateDescription: (ref, actionRequired) =>
-                        ref.read(curNoteProvider.notifier).updateActionRequired(actionRequired),
+                    updateDescription: (ref, actionRequired) => ref
+                        .read(curNoteProvider.notifier)
+                        .updateActionRequired(actionRequired),
                   ),
                   const Divider(),
                   BaseTextBlockEditSelectionField(
@@ -80,22 +81,11 @@ class NotePage extends HookConsumerWidget {
                 width: double.infinity,
                 child: ElevatedButton(
                   onPressed: () async {
-                    final curAuthUser = ref.watch(curAuthUserProvider);
-
-                    if (curAuthUser == null) {
-                      log.severe('Error: Current user is not authenticated.');
-                      return;
-                    }
-
                     final isValidNote =
                         ref.read(curNoteProvider.notifier).isValidNote();
-                        
-                    // TODO p2: add validator ui - since we don't use formfield (since we use provider to manage task form state) we must manually implement validation
 
                     if (isValidNote) {
-                      final curNote = ref.read(curNoteProvider);
-                      
-                      await ref.read(notesReadProvider).upsertItem(curNote);
+                      ref.read(curNoteProvider.notifier).saveNote();
 
                       if (context.mounted) {
                         Navigator.pop(context);
@@ -118,7 +108,7 @@ class NotePage extends HookConsumerWidget {
                     Navigator.pop(context);
                     openNotePage(context, ref, mode: EditablePageMode.edit);
                   },
-                  child: Text('Edit'))
+                  child: const Text('Edit'))
           ],
         ),
       ),
@@ -128,7 +118,9 @@ class NotePage extends HookConsumerWidget {
 
 // TODO p2: init state within the page itself ... we should only rely on arguments to init the page (to support deep linking)
 Future<void> openNotePage(BuildContext context, WidgetRef ref,
-    {required EditablePageMode mode, String? parentNoteFolderId, String? noteId}) async {
+    {required EditablePageMode mode,
+    String? parentNoteFolderId,
+    String? noteId}) async {
   Navigator.popUntil(context, (route) => route.settings.name != notePageRoute);
 
   if (mode == EditablePageMode.create) {
@@ -141,13 +133,17 @@ Future<void> openNotePage(BuildContext context, WidgetRef ref,
       throw Exception('Error: Current user is not authenticated.');
     }
 
-    if(parentNoteFolderId == null) {
-      throw ArgumentError('Error: Parent note folder id is required for creating a note.');
+    if (parentNoteFolderId == null) {
+      throw ArgumentError(
+          'Error: Parent note folder id is required for creating a note.');
     }
-    
-    // TODO p3: maybe you can select the parent folder instead in a note 
-    ref.read(curNoteProvider.notifier).setToNewNote(authUser, parentNoteFolderId);
-  } else if (mode == EditablePageMode.edit || mode == EditablePageMode.readOnly) {
+
+    // TODO p3: maybe you can select the parent folder instead in a note
+    ref
+        .read(curNoteProvider.notifier)
+        .setToNewNote(authUser, parentNoteFolderId);
+  } else if (mode == EditablePageMode.edit ||
+      mode == EditablePageMode.readOnly) {
     if (noteId != null) {
       final note = await ref.read(notesReadProvider).getItem(id: noteId);
       if (note != null) {
@@ -156,6 +152,5 @@ Future<void> openNotePage(BuildContext context, WidgetRef ref,
     }
   }
 
-  await Navigator.pushNamed(context, notePageRoute,
-      arguments: {'mode': mode });
+  await Navigator.pushNamed(context, notePageRoute, arguments: {'mode': mode});
 }

--- a/lib/services/data/shifts/cur_shifts/cur_user_joined_shifts_listener_provider.dart
+++ b/lib/services/data/shifts/cur_shifts/cur_user_joined_shifts_listener_provider.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:seren_ai_flutter/services/auth/auth_states.dart';
+import 'package:seren_ai_flutter/services/auth/cur_auth_user_provider.dart';
 import 'package:seren_ai_flutter/services/data/projects/projects_read_provider.dart';
 import 'package:seren_ai_flutter/services/data/shifts/cur_shifts/cur_user_shifts_listener_provider.dart';
 import 'package:seren_ai_flutter/services/data/shifts/models/joined_shift_model.dart';
@@ -34,6 +36,14 @@ class CurUserJoinedShiftsListenerNotifier
         parentProject: project,
       );
     }).toList();
+
+    final curAuthUserState = ref.read(curAuthUserProvider);
+    if (curAuthUserState is LoggedInAuthState) {
+      final curAuthUserDefaultProjectId =
+          curAuthUserState.user.defaultProjectId;
+      joinedShifts.sort((a, b) =>
+          (a.parentProject?.id ?? '') == curAuthUserDefaultProjectId ? -1 : 1);
+    }
 
     state = joinedShifts;
   }

--- a/lib/services/data/tasks/ui_state/cur_task_provider.dart
+++ b/lib/services/data/tasks/ui_state/cur_task_provider.dart
@@ -3,143 +3,261 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:seren_ai_flutter/services/auth/auth_states.dart';
 import 'package:seren_ai_flutter/services/auth/cur_auth_user_provider.dart';
 import 'package:seren_ai_flutter/services/data/projects/models/project_model.dart';
+import 'package:seren_ai_flutter/services/data/projects/projects_read_provider.dart';
 import 'package:seren_ai_flutter/services/data/tasks/models/joined_task_model.dart';
 import 'package:seren_ai_flutter/services/data/tasks/models/task_comments_model.dart';
 import 'package:seren_ai_flutter/services/data/tasks/models/task_model.dart';
 import 'package:seren_ai_flutter/services/data/tasks/task_comments/task_comments_listener_fam_provider.dart';
 import 'package:seren_ai_flutter/services/data/tasks/task_comments_db_provider.dart';
 import 'package:seren_ai_flutter/services/data/teams/models/team_model.dart';
+import 'package:seren_ai_flutter/services/data/teams/teams_read_provider.dart';
 import 'package:seren_ai_flutter/services/data/users/models/user_model.dart';
+import 'package:seren_ai_flutter/services/data/tasks/ui_state/cur_task_states.dart';
 
 final curTaskProvider =
-    NotifierProvider<CurTaskNotifier, JoinedTaskModel>(CurTaskNotifier.new);
+    NotifierProvider<CurTaskNotifier, CurTaskState>(CurTaskNotifier.new);
 
-class CurTaskNotifier extends Notifier<JoinedTaskModel> {
+class CurTaskNotifier extends Notifier<CurTaskState> {
   @override
-  JoinedTaskModel build() {
-    return JoinedTaskModel.empty();
+  CurTaskState build() {
+    return InitialCurTaskState();
   }
 
   void setNewTask(JoinedTaskModel joinedTask) {
-    state = joinedTask;
+    state = LoadedCurTaskState(joinedTask);
   }
 
-  void setToNewTask(UserModel authorUser) {
-    state = JoinedTaskModel.empty().copyWith(authorUser: authorUser, task: TaskModel.defaultTask().copyWith(authorUserId: authorUser.id));
+  Future<void> setToNewTask() async {
+    state = LoadingCurTaskState();
+    try {
+      final curAuthUserState = ref.read(curAuthUserProvider);
+      if (switch (curAuthUserState) {
+        LoggedInAuthState() => curAuthUserState.user,
+        _ => null,
+      }
+          case final curUser?) {
+        final defaultTeam =
+            await ref.read(teamsReadProvider).getItem(eqFilters: [
+          {'key': 'id', 'value': curUser.defaultTeamId}
+        ]);
+        final defaultProject =
+            await ref.read(projectsReadProvider).getItem(eqFilters: [
+          {'key': 'id', 'value': curUser.defaultProjectId}
+        ]);
+        final newTask = JoinedTaskModel.empty().copyWith(
+          authorUser: curUser,
+          task: TaskModel.defaultTask().copyWith(
+            authorUserId: curUser.id,
+            parentTeamId: defaultTeam?.id,
+            parentProjectId: defaultProject?.id,
+          ),
+          team: defaultTeam,
+          project: defaultProject,
+        );
+        state = LoadedCurTaskState(newTask);
+      } else {
+        throw Exception('Error: Current user is not authenticated.');
+      }
+    } catch (error) {
+      state = ErrorCurTaskState(error: error.toString());
+    }
   }
 
   bool isValidTask() {
-    return state.task.name.isNotEmpty && state.task.parentProjectId.isNotEmpty;
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      return loadedState.task.task.name.isNotEmpty &&
+          loadedState.task.task.parentProjectId.isNotEmpty;
+    }
+    return false;
   }
 
   void updateAssignees(List<UserModel> assignees) {
-    state = state.copyWith(
-      assignees: assignees,
-    );
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state =
+          LoadedCurTaskState(loadedState.task.copyWith(assignees: assignees));
+    }
   }
 
   void updateTask(TaskModel task) {
-    state = state.copyWith(task: task);
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state = LoadedCurTaskState(loadedState.task.copyWith(task: task));
+    }
   }
 
-  // We must showDatePicker and update in same method 
-  // As the original ref is invalidated after showDatePicker returns 
+  void updateStatus(StatusEnum? status) {
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state = LoadedCurTaskState(loadedState.task
+          .copyWith(task: loadedState.task.task.copyWith(status: status)));
+    }
+  }
+
+  void updatePriority(PriorityEnum? priority) {
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state = LoadedCurTaskState(loadedState.task
+          .copyWith(task: loadedState.task.task.copyWith(priority: priority)));
+    }
+  }
+
+  void updateDescription(String? description) {
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state = LoadedCurTaskState(loadedState.task.copyWith(
+          task: loadedState.task.task.copyWith(description: description)));
+    }
+  }
+
+  // We must showDatePicker and update in same method
+  // As the original ref is invalidated after showDatePicker returns
+
   Future<void> pickAndUpdateDueDate(BuildContext context) async {
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      final DateTime now = DateTime.now();
+      final DateTime initialDate =
+          loadedState.task.task.dueDate?.toLocal() ?? now;
 
-    final DateTime now = DateTime.now();
-    final DateTime initialDate = state.task.dueDate?.toLocal() ?? now;
+      final DateTime? pickedDate = await showDatePicker(
+        context: context,
+        initialDate: initialDate,
+        firstDate: DateTime(2000),
+        lastDate: DateTime(2100),
+      );
 
-    final DateTime? pickedDate = await showDatePicker(
-      context: context,
-      initialDate: initialDate,
-      firstDate: DateTime(2000),
-      lastDate: DateTime(2100),
-    );
+      if (pickedDate != null) {
+        final TimeOfDay? pickedTime = await showTimePicker(
+          context: context,
+          initialTime: TimeOfDay.fromDateTime(initialDate),
+        );
 
-    if (pickedDate != null) {
-          final TimeOfDay? pickedTime = await showTimePicker(
-            context: context,
-            initialTime: TimeOfDay.fromDateTime(initialDate),
-          );
+        if (pickedTime != null) {
+          final DateTime pickedDateTime = DateTime(
+            pickedDate.year,
+            pickedDate.month,
+            pickedDate.day,
+            pickedTime.hour,
+            pickedTime.minute,
+          ).toUtc();
 
-          if (pickedTime != null) {
-            final DateTime pickedDateTime = DateTime(
-              pickedDate.year,
-              pickedDate.month,
-              pickedDate.day,
-              pickedTime.hour,
-              pickedTime.minute,
-            ).toUtc();
-
-            updateDueDate(pickedDateTime);
+          updateDueDate(pickedDateTime);
+        }
       }
     }
   }
 
   void updateTaskName(String name) {
-    state = state.copyWith(task: state.task.copyWith(name: name));
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state = LoadedCurTaskState(loadedState.task
+          .copyWith(task: loadedState.task.task.copyWith(name: name)));
+    }
   }
 
   void updateDueDate(DateTime? dueDate) {
-    state = state.copyWith(task: state.task.copyWith(dueDate: dueDate));
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state = LoadedCurTaskState(loadedState.task
+          .copyWith(task: loadedState.task.task.copyWith(dueDate: dueDate)));
+    }
   }
 
   void updateParentProject(ProjectModel? project) {
-    state = state.copyWith(task: state.task.copyWith(parentProjectId: project?.id), project: project);
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state = LoadedCurTaskState(loadedState.task.copyWith(
+          task: loadedState.task.task.copyWith(parentProjectId: project?.id),
+          project: project));
+    }
   }
 
   void updateTeam(TeamModel? team) {
-    state = state.copyWith(task: state.task.copyWith(parentTeamId: team?.id), team: team);
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      state = LoadedCurTaskState(loadedState.task.copyWith(
+          task: loadedState.task.task.copyWith(parentTeamId: team?.id),
+          team: team));
+    }
   }
 
   void updateAllFields(JoinedTaskModel joinedTask) {
-    state = joinedTask;
+    state = LoadedCurTaskState(joinedTask);
   }
 
   void addComment(String text) {
-    final curAuthUserState = ref.read(curAuthUserProvider);
-    final curUser = switch (curAuthUserState) {
-      LoggedInAuthState() => curAuthUserState.user,
-      _ => null,
-    };
-    final comment = TaskCommentsModel(
-      authorUserId: curUser!.id,
-      parentTaskId: state.task.id,
-      content: text,
-      createdAt: DateTime.now().toUtc(),
-      updatedAt: DateTime.now().toUtc(),
-    );
-    ref.read(taskCommentsDbProvider).upsertItem(comment);
-    state = state.copyWith(comments: [...state.comments, comment]);
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      final curAuthUserState = ref.read(curAuthUserProvider);
+      final curUser = switch (curAuthUserState) {
+        LoggedInAuthState() => curAuthUserState.user,
+        _ => null,
+      };
+      final comment = TaskCommentsModel(
+        authorUserId: curUser!.id,
+        parentTaskId: loadedState.task.task.id,
+        content: text,
+        createdAt: DateTime.now().toUtc(),
+        updatedAt: DateTime.now().toUtc(),
+      );
+      ref.read(taskCommentsDbProvider).upsertItem(comment);
+      state = LoadedCurTaskState(loadedState.task
+          .copyWith(comments: [...loadedState.task.comments, comment]));
+    }
   }
 
   Future<void> updateComments() async {
-    final comments =
-        ref.read(taskCommentsListenerFamProvider(state.task.id)) ?? [];
+    if (state is LoadedCurTaskState) {
+      final loadedState = state as LoadedCurTaskState;
+      final comments =
+          ref.read(taskCommentsListenerFamProvider(loadedState.task.task.id)) ??
+              [];
 
-    state = state.copyWith(comments: comments);
+      state = LoadedCurTaskState(loadedState.task.copyWith(comments: comments));
+    }
   }
 }
 
 // Providers for individual fields
 
 final curTaskAssigneesProvider = Provider<List<UserModel>>((ref) {
-  return ref.watch(curTaskProvider.select((state) => 
-    state.assignees));
+  final curTaskState = ref.watch(curTaskProvider);
+  return switch (curTaskState) {
+    LoadedCurTaskState() => curTaskState.task.assignees,
+    _ => [],
+  };
 });
 
 final curTaskProjectProvider = Provider<ProjectModel?>((ref) {
-  return ref.watch(curTaskProvider.select((state) => state.project));
+  final curTaskState = ref.watch(curTaskProvider);
+  return switch (curTaskState) {
+    LoadedCurTaskState() => curTaskState.task.project,
+    _ => null,
+  };
 });
 
 final curTaskTeamProvider = Provider<TeamModel?>((ref) {
-  return ref.watch(curTaskProvider.select((state) => state.team));
+  final curTaskState = ref.watch(curTaskProvider);
+  return switch (curTaskState) {
+    LoadedCurTaskState() => curTaskState.task.team,
+    _ => null,
+  };
 });
 
 final curTaskProjectIdProvider = Provider<String?>((ref) {
-  return ref.watch(curTaskProvider.select((state) => state.task.parentProjectId));
+  final curTaskState = ref.watch(curTaskProvider);
+  return switch (curTaskState) {
+    LoadedCurTaskState() => curTaskState.task.task.parentProjectId,
+    _ => null,
+  };
 });
 
 final curTaskDueDateProvider = Provider<DateTime?>((ref) {
-  return ref.watch(curTaskProvider.select((state) => state.task.dueDate));
+  final curTaskState = ref.watch(curTaskProvider);
+  return switch (curTaskState) {
+    LoadedCurTaskState() => curTaskState.task.task.dueDate,
+    _ => null,
+  };
 });

--- a/lib/services/data/tasks/ui_state/cur_task_states.dart
+++ b/lib/services/data/tasks/ui_state/cur_task_states.dart
@@ -1,0 +1,21 @@
+import 'package:seren_ai_flutter/services/data/tasks/models/joined_task_model.dart';
+
+sealed class CurTaskState {}
+
+class InitialCurTaskState extends CurTaskState {}
+
+class LoadingCurTaskState extends CurTaskState {}
+
+class LoadedCurTaskState extends CurTaskState {
+  final JoinedTaskModel task;
+
+  LoadedCurTaskState(this.task);
+}
+
+class EmptyCurTaskState extends CurTaskState {}
+
+class ErrorCurTaskState extends CurTaskState {
+  final String error;
+
+  ErrorCurTaskState({required this.error});
+}

--- a/lib/services/data/tasks/widgets/form/task_selection_fields.dart
+++ b/lib/services/data/tasks/widgets/form/task_selection_fields.dart
@@ -8,6 +8,7 @@ import 'package:seren_ai_flutter/services/data/common/widgets/form/base_task_nam
 import 'package:seren_ai_flutter/services/data/common/widgets/form/base_team_selection_field.dart';
 import 'package:seren_ai_flutter/services/data/projects/cur_user_viewable_projects_listener_provider.dart';
 import 'package:seren_ai_flutter/services/data/tasks/ui_state/cur_task_provider.dart';
+import 'package:seren_ai_flutter/services/data/tasks/ui_state/cur_task_states.dart';
 import 'package:seren_ai_flutter/services/data/teams/cur_team/cur_user_viewable_teams_listener_provider.dart';
 
 class TaskTeamSelectionField extends BaseTeamSelectionField {
@@ -15,7 +16,10 @@ class TaskTeamSelectionField extends BaseTeamSelectionField {
     super.key,
     required super.enabled,
   }) : super(
-          teamProvider: curTaskTeamProvider,
+          teamProvider: curTaskProvider.select((state) => switch (state) {
+                LoadedCurTaskState() => state.task.team,
+                _ => null,
+              }),
           selectableTeamsProvider: curUserViewableTeamsListenerProvider,
           updateTeam: (ref, team) =>
               ref.read(curTaskProvider.notifier).updateTeam(team),
@@ -39,11 +43,12 @@ class TaskStatusSelectionField extends BaseStatusSelectionField {
     super.key,
     required super.enabled,
   }) : super(
-          statusProvider: curTaskProvider.select((state) => state.task.status),
-          updateStatus: (ref, status) => ref
-              .read(curTaskProvider.notifier)
-              .updateTask(
-                  ref.read(curTaskProvider).task.copyWith(status: status)),
+          statusProvider: curTaskProvider.select((state) => switch (state) {
+                LoadedCurTaskState() => state.task.task.status,
+                _ => null,
+              }),
+          updateStatus: (ref, status) =>
+              ref.read(curTaskProvider.notifier).updateStatus(status),
         );
 }
 
@@ -52,12 +57,12 @@ class TaskPrioritySelectionField extends BasePrioritySelectionField {
     super.key,
     required super.enabled,
   }) : super(
-          priorityProvider:
-              curTaskProvider.select((state) => state.task.priority),
-          updatePriority: (ref, priority) => ref
-              .read(curTaskProvider.notifier)
-              .updateTask(
-                  ref.read(curTaskProvider).task.copyWith(priority: priority)),
+          priorityProvider: curTaskProvider.select((state) => switch (state) {
+                LoadedCurTaskState() => state.task.task.priority,
+                _ => null,
+              }),
+          updatePriority: (ref, priority) =>
+              ref.read(curTaskProvider.notifier).updatePriority(priority),
         );
 }
 
@@ -66,8 +71,11 @@ class TaskNameField extends BaseNameField {
     super.key,
     required super.enabled,
   }) : super(
-          nameProvider: curTaskProvider.select((state) => state.task.name),
-          updateName: (ref, name) => 
+          nameProvider: curTaskProvider.select((state) => switch (state) {
+                LoadedCurTaskState() => state.task.task.name,
+                _ => '',
+              }),
+          updateName: (ref, name) =>
               ref.read(curTaskProvider.notifier).updateTaskName(name),
         );
 }
@@ -77,22 +85,26 @@ class TaskDueDateSelectionField extends BaseDueDateSelectionField {
     super.key,
     required super.enabled,
   }) : super(
-          dueDateProvider: curTaskDueDateProvider,
-          pickAndUpdateDueDate: (ref, context) => 
+          dueDateProvider: curTaskProvider.select((state) => switch (state) {
+                LoadedCurTaskState() => state.task.task.dueDate,
+                _ => null,
+              }),
+          pickAndUpdateDueDate: (ref, context) =>
               ref.read(curTaskProvider.notifier).pickAndUpdateDueDate(context),
         );
 }
 
 class TaskDescriptionSelectionField extends BaseTextBlockEditSelectionField {
- TaskDescriptionSelectionField({
+  TaskDescriptionSelectionField({
     super.key,
     required super.enabled,
   }) : super(
-          descriptionProvider: curTaskProvider.select((state) => state.task.description),
-          updateDescription: (ref, description) => 
-              ref.read(curTaskProvider.notifier).updateTask(
-                ref.read(curTaskProvider).task.copyWith(description: description)
-              ),
+          descriptionProvider: curTaskProvider.select((state) => switch (state) {
+                LoadedCurTaskState() => state.task.task.description,
+                _ => null,
+              }),
+          updateDescription: (ref, description) =>
+              ref.read(curTaskProvider.notifier).updateDescription(description),
         );
 }
 
@@ -101,9 +113,8 @@ class TaskAssigneesSelectionField extends BaseAssigneesSelectionField {
     super.key,
     required super.enabled,
   }) : super(
-          assigneesProvider: curTaskAssigneesProvider,
-          projectProvider: curTaskProjectProvider,
-          updateAssignees: (ref, assignees) =>
-              ref.read(curTaskProvider.notifier).updateAssignees(assignees)
-        );
+            assigneesProvider: curTaskAssigneesProvider,
+            projectProvider: curTaskProjectProvider,
+            updateAssignees: (ref, assignees) =>
+                ref.read(curTaskProvider.notifier).updateAssignees(assignees));
 }

--- a/lib/services/data/users/models/user_model.dart
+++ b/lib/services/data/users/models/user_model.dart
@@ -18,11 +18,19 @@ class UserModel implements IHasId {
   @JsonKey(name: 'updated_at')
   final DateTime? updatedAt;
 
+  @JsonKey(name: 'default_project_id')
+  final String? defaultProjectId;
+
+  @JsonKey(name: 'default_team_id')
+  final String? defaultTeamId;
+
   UserModel({
     String? id,
     required this.parentAuthUserId,
     required this.email,
     this.createdAt,
+    this.defaultProjectId,
+    this.defaultTeamId,
     this.updatedAt,
   }) : id = id ?? uuid.v4();
 

--- a/lib/services/data/users/models/user_model.g.dart
+++ b/lib/services/data/users/models/user_model.g.dart
@@ -13,6 +13,8 @@ UserModel _$UserModelFromJson(Map<String, dynamic> json) => UserModel(
       createdAt: json['created_at'] == null
           ? null
           : DateTime.parse(json['created_at'] as String),
+      defaultProjectId: json['default_project_id'] as String?,
+      defaultTeamId: json['default_team_id'] as String?,
       updatedAt: json['updated_at'] == null
           ? null
           : DateTime.parse(json['updated_at'] as String),
@@ -24,4 +26,6 @@ Map<String, dynamic> _$UserModelToJson(UserModel instance) => <String, dynamic>{
       'email': instance.email,
       'created_at': instance.createdAt?.toIso8601String(),
       'updated_at': instance.updatedAt?.toIso8601String(),
+      'default_project_id': instance.defaultProjectId,
+      'default_team_id': instance.defaultTeamId,
     };

--- a/lib/widgets/test_sql_page.dart
+++ b/lib/widgets/test_sql_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:powersync/powersync.dart' hide Column;
-import 'package:seren_ai_flutter/services/auth/cur_auth_user_provider.dart';
 import 'package:seren_ai_flutter/services/data/db_setup/db_provider.dart';
 import 'package:seren_ai_flutter/services/data/users/models/user_model.dart';
 
@@ -17,11 +14,6 @@ class TasksNotifier extends Notifier<List<UserModel>> {
   // We initialize the list of tasks to an empty list
   @override
   List<UserModel> build() {
-    final user = ref.watch(curAuthUserProvider); 
-    if(user == null) {
-      return [];
-    }
-
     _listen();
 
     return [];

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -604,18 +604,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -652,18 +652,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -1185,10 +1185,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   timing:
     dependency: transitive
     description:
@@ -1345,10 +1345,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
- read new default user project and team when creating tasks and notes
- automatically show the shift that is associated with user's default project
- removed unnecessary auth double-checking from some files
- since tasks and notes weren't correctly refreshing the default values, the new state management approach was already implemented for them too
- comments about validator ui were removed due to it's already working from previous version