### PR TITLE
refactor(home): use both label and icon in home tabs for all screens

### DIFF
--- a/lib/widgets/home/home_page.dart
+++ b/lib/widgets/home/home_page.dart
@@ -57,12 +57,12 @@ class _HomePageState extends ConsumerState<HomePage>
     ];
 
     // Calculate available width for tabs
-    final screenWidth = MediaQuery.of(context).size.width;
+    // final screenWidth = MediaQuery.of(context).size.width;
 
     // Check if screen is too narrow for full tab labels
     // 70 is the average width of a tab label
     // 32 is the default horizontal padding
-    final isNarrowScreen = screenWidth - 32 < (70 + 32) * tabs.length;
+    // final isNarrowScreen = screenWidth - 32 < (70 + 32) * tabs.length;
 
     return Scaffold(
       body: Column(
@@ -78,9 +78,7 @@ class _HomePageState extends ConsumerState<HomePage>
           TabBar(
             controller: _tabController,
             tabs: tabs
-                .map((tab) => Tab(
-                    text: isNarrowScreen ? null : tab.label,
-                    icon: isNarrowScreen ? Icon(tab.icon) : null))
+                .map((tab) => Tab(text: tab.label, icon: Icon(tab.icon)))
                 .toList(),
           ),
 
@@ -88,22 +86,7 @@ class _HomePageState extends ConsumerState<HomePage>
           Expanded(
             child: TabBarView(
               controller: _tabController,
-              children: tabs
-                  .map(
-                    (tab) => isNarrowScreen
-                        ? Column(
-                            children: [
-                              const SizedBox(height: 16),
-                              Text(
-                                tab.label,
-                                style: Theme.of(context).textTheme.titleLarge,
-                              ),
-                              Expanded(child: tab.body),
-                            ],
-                          )
-                        : tab.body,
-                  )
-                  .toList(),
+              children: tabs.map((tab) => tab.body).toList(),
             ),
           ),
         ],


### PR DESCRIPTION
There's no label style option, but I think this font size is pretty good and responsive

![image](https://github.com/user-attachments/assets/7cf19ed1-f31a-41a0-96a6-e906afd6c4ad)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the tab navigation by removing conditional layout adjustments based on screen size. All tabs now consistently display both labels and icons, ensuring a uniform and straightforward user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->